### PR TITLE
Remove hero section from homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,20 +2,6 @@
 layout: default
 ---
 
-<!-- Hero Section -->
-<div class="nrv-hero">
-  <div class="container">
-    <div class="row justify-content-center">
-      <div class="col-12 col-lg-8 text-center">
-        <h1 class="nrv-hero-title">نارون</h1>
-        <p class="nrv-hero-subtitle">مجله‌ای برای بچه‌های آمستردام</p>
-        <div class="nrv-hero-divider"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- Main Content -->
 <div class="col-12 col-lg-10 offset-lg-1">
 
   <!-- Magazine Issues Section -->

--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -16,7 +16,7 @@ p {
 }
 
 body > .container {
-    margin-top: 0;
+    margin-top: 40px;
     margin-bottom: 40px;
 }
 


### PR DESCRIPTION
- Removed gradient hero banner with title and subtitle
- Restored top margin to main container (40px)
- Cleaner, simpler homepage layout
- Magazine cards and articles now appear directly